### PR TITLE
Update to 1.6

### DIFF
--- a/common/decisions/bm_major_decisions.txt
+++ b/common/decisions/bm_major_decisions.txt
@@ -45,7 +45,7 @@ enhance_blood_mage_coven_decision_1 = {
 
 		house = {
 			custom_tooltip = {
-				text = found_blood_mage_coven_house_member_count_tt
+				text = found_bm_coven_member_count_tt
 				any_adult_house_member = {
 					count >= found_bm_coven_member_count
 					has_trait = blood_mage
@@ -91,14 +91,14 @@ enhance_blood_mage_coven_decision_2 = {
 		exists = house
 		house = {
 			custom_tooltip = {
-				text = found_blood_mage_coven_house_member_count_tt
+				text = found_bm_coven_member_count_tt
 				any_adult_house_member = {
-					count >= found_bm_coven_member_count_2
+					count >= found_bm_coven_member_count
 					has_trait = blood_mage
 				}
 			}
 			any_adult_house_member = {
-				count >= found_bm_coven_member_count_2
+				count >= found_bm_coven_member_count
 				has_trait = blood_mage
 			}
 		}
@@ -153,14 +153,14 @@ enhance_blood_mage_coven_decision_3 = {
 		has_character_modifier = lifeforce_modifier
 		house = {
 			custom_tooltip = {
-				text = found_blood_mage_coven_house_member_count_tt
+				text = found_bm_coven_member_count_tt
 				any_adult_house_member = {
-					count >= found_bm_coven_member_count_3
+					count >= found_bm_coven_member_count
 					has_trait = blood_mage
 				}
 			}
 			any_adult_house_member = {
-				count >= found_bm_coven_member_count_3
+				count >= found_bm_coven_member_count
 				has_trait = blood_mage
 			}
 		}
@@ -213,14 +213,14 @@ enhance_blood_mage_coven_decision_4 = {
 		has_character_modifier = lifeforce_modifier
 		house = {
 			custom_tooltip = {
-				text = found_blood_mage_coven_house_member_count_tt
+				text = found_bm_coven_member_count_tt
 				any_adult_house_member = {
-					count >= found_bm_coven_member_count_4
+					count >= found_bm_coven_member_count
 					has_trait = blood_mage
 				}
 			}
 			any_adult_house_member = {
-				count >= found_bm_coven_member_count_4
+				count >= found_bm_coven_member_count
 				has_trait = blood_mage
 			}
 		}
@@ -273,14 +273,14 @@ enhance_blood_mage_coven_decision_5 = {
 		has_character_modifier = lifeforce_modifier
 		house = {
 			custom_tooltip = {
-				text = found_blood_mage_coven_house_member_count_tt
+				text = found_bm_coven_member_count_tt
 				any_adult_house_member = {
-					count >= found_bm_coven_member_count_5
+					count >= found_bm_coven_member_count
 					has_trait = blood_mage
 				}
 			}
 			any_adult_house_member = {
-				count >= found_bm_coven_member_count_5
+				count >= found_bm_coven_member_count
 				has_trait = blood_mage
 			}
 		}
@@ -333,14 +333,14 @@ enhance_blood_mage_coven_decision_6 = {
 		has_character_modifier = lifeforce_modifier
 		house = {
 			custom_tooltip = {
-				text = found_blood_mage_coven_house_member_count_tt
+				text = found_bm_coven_member_count_tt
 				any_adult_house_member = {
-					count >= found_bm_coven_member_count_6
+					count >= found_bm_coven_member_count
 					has_trait = blood_mage
 				}
 			}
 			any_adult_house_member = {
-				count >= found_bm_coven_member_count_6
+				count >= found_bm_coven_member_count
 				has_trait = blood_mage
 			}
 		}
@@ -393,14 +393,14 @@ enhance_blood_mage_coven_decision_7 = {
 		has_character_modifier = lifeforce_modifier
 		house = {
 			custom_tooltip = {
-				text = found_blood_mage_coven_house_member_count_tt
+				text = found_bm_coven_member_count_tt
 				any_adult_house_member = {
-					count >= found_bm_coven_member_count_7
+					count >= found_bm_coven_member_count
 					has_trait = blood_mage
 				}
 			}
 			any_adult_house_member = {
-				count >= found_bm_coven_member_count_7
+				count >= found_bm_coven_member_count
 				has_trait = blood_mage
 			}
 		}
@@ -454,14 +454,14 @@ enhance_blood_mage_coven_decision_8 = {
 		has_character_modifier = lifeforce_modifier
 		house = {
 			custom_tooltip = {
-				text = found_blood_mage_coven_house_member_count_tt
+				text = found_bm_coven_member_count_tt
 				any_adult_house_member = {
-					count >= found_bm_coven_member_count_8
+					count >= found_bm_coven_member_count
 					has_trait = blood_mage
 				}
 			}
 			any_adult_house_member = {
-				count >= found_bm_coven_member_count_8
+				count >= found_bm_coven_member_count
 				has_trait = blood_mage
 			}
 		}
@@ -514,14 +514,14 @@ enhance_blood_mage_coven_decision_9 = {
 		has_character_modifier = lifeforce_modifier
 		house = {
 			custom_tooltip = {
-				text = found_blood_mage_coven_house_member_count_tt
+				text = found_bm_coven_member_count_tt
 				any_adult_house_member = {
-					count >= found_bm_coven_member_count_9
+					count >= found_bm_coven_member_count
 					has_trait = blood_mage
 				}
 			}
 			any_adult_house_member = {
-				count >= found_bm_coven_member_count_9
+				count >= found_bm_coven_member_count
 				has_trait = blood_mage
 			}
 		}
@@ -575,14 +575,14 @@ enhance_blood_mage_coven_decision_10 = {
 		has_character_modifier = lifeforce_modifier
 		house = {
 			custom_tooltip = {
-				text = found_blood_mage_coven_house_member_count_tt
+				text = found_bm_coven_member_count_tt
 				any_adult_house_member = {
-					count >= found_bm_coven_member_count_10
+					count >= found_bm_coven_member_count
 					has_trait = blood_mage
 				}
 			}
 			any_adult_house_member = {
-				count >= found_bm_coven_member_count_10
+				count >= found_bm_coven_member_count
 				has_trait = blood_mage
 			}
 		}

--- a/common/decisions/bm_major_decisions.txt
+++ b/common/decisions/bm_major_decisions.txt
@@ -46,12 +46,12 @@ enhance_blood_mage_coven_decision_1 = {
 		house = {
 			custom_tooltip = {
 				text = found_bm_coven_member_count_tt
-				any_adult_house_member = {
+				any_house_member = {
 					count >= found_bm_coven_member_count
 					has_trait = blood_mage
 				}
 			}
-			any_adult_house_member = {
+			any_house_member = {
 				count >= found_bm_coven_member_count
 				has_trait = blood_mage
 			}
@@ -92,12 +92,12 @@ enhance_blood_mage_coven_decision_2 = {
 		house = {
 			custom_tooltip = {
 				text = found_bm_coven_member_count_tt
-				any_adult_house_member = {
+				any_house_member = {
 					count >= found_bm_coven_member_count
 					has_trait = blood_mage
 				}
 			}
-			any_adult_house_member = {
+			any_house_member = {
 				count >= found_bm_coven_member_count
 				has_trait = blood_mage
 			}
@@ -154,12 +154,12 @@ enhance_blood_mage_coven_decision_3 = {
 		house = {
 			custom_tooltip = {
 				text = found_bm_coven_member_count_tt
-				any_adult_house_member = {
+				any_house_member = {
 					count >= found_bm_coven_member_count
 					has_trait = blood_mage
 				}
 			}
-			any_adult_house_member = {
+			any_house_member = {
 				count >= found_bm_coven_member_count
 				has_trait = blood_mage
 			}
@@ -214,12 +214,12 @@ enhance_blood_mage_coven_decision_4 = {
 		house = {
 			custom_tooltip = {
 				text = found_bm_coven_member_count_tt
-				any_adult_house_member = {
+				any_house_member = {
 					count >= found_bm_coven_member_count
 					has_trait = blood_mage
 				}
 			}
-			any_adult_house_member = {
+			any_house_member = {
 				count >= found_bm_coven_member_count
 				has_trait = blood_mage
 			}
@@ -274,12 +274,12 @@ enhance_blood_mage_coven_decision_5 = {
 		house = {
 			custom_tooltip = {
 				text = found_bm_coven_member_count_tt
-				any_adult_house_member = {
+				any_house_member = {
 					count >= found_bm_coven_member_count
 					has_trait = blood_mage
 				}
 			}
-			any_adult_house_member = {
+			any_house_member = {
 				count >= found_bm_coven_member_count
 				has_trait = blood_mage
 			}
@@ -334,12 +334,12 @@ enhance_blood_mage_coven_decision_6 = {
 		house = {
 			custom_tooltip = {
 				text = found_bm_coven_member_count_tt
-				any_adult_house_member = {
+				any_house_member = {
 					count >= found_bm_coven_member_count
 					has_trait = blood_mage
 				}
 			}
-			any_adult_house_member = {
+			any_house_member = {
 				count >= found_bm_coven_member_count
 				has_trait = blood_mage
 			}
@@ -394,12 +394,12 @@ enhance_blood_mage_coven_decision_7 = {
 		house = {
 			custom_tooltip = {
 				text = found_bm_coven_member_count_tt
-				any_adult_house_member = {
+				any_house_member = {
 					count >= found_bm_coven_member_count
 					has_trait = blood_mage
 				}
 			}
-			any_adult_house_member = {
+			any_house_member = {
 				count >= found_bm_coven_member_count
 				has_trait = blood_mage
 			}
@@ -455,12 +455,12 @@ enhance_blood_mage_coven_decision_8 = {
 		house = {
 			custom_tooltip = {
 				text = found_bm_coven_member_count_tt
-				any_adult_house_member = {
+				any_house_member = {
 					count >= found_bm_coven_member_count
 					has_trait = blood_mage
 				}
 			}
-			any_adult_house_member = {
+			any_house_member = {
 				count >= found_bm_coven_member_count
 				has_trait = blood_mage
 			}
@@ -515,12 +515,12 @@ enhance_blood_mage_coven_decision_9 = {
 		house = {
 			custom_tooltip = {
 				text = found_bm_coven_member_count_tt
-				any_adult_house_member = {
+				any_house_member = {
 					count >= found_bm_coven_member_count
 					has_trait = blood_mage
 				}
 			}
-			any_adult_house_member = {
+			any_house_member = {
 				count >= found_bm_coven_member_count
 				has_trait = blood_mage
 			}
@@ -576,12 +576,12 @@ enhance_blood_mage_coven_decision_10 = {
 		house = {
 			custom_tooltip = {
 				text = found_bm_coven_member_count_tt
-				any_adult_house_member = {
+				any_house_member = {
 					count >= found_bm_coven_member_count
 					has_trait = blood_mage
 				}
 			}
-			any_adult_house_member = {
+			any_house_member = {
 				count >= found_bm_coven_member_count
 				has_trait = blood_mage
 			}

--- a/common/decisions/bm_major_decisions.txt
+++ b/common/decisions/bm_major_decisions.txt
@@ -47,12 +47,12 @@ enhance_blood_mage_coven_decision_1 = {
 			custom_tooltip = {
 				text = found_blood_mage_coven_house_member_count_tt
 				any_adult_house_member = {
-					count >= found_blood_mage_coven_member_count_value
+					count >= found_bm_coven_member_count
 					has_trait = blood_mage
 				}
 			}
 			any_adult_house_member = {
-				count >= found_blood_mage_coven_member_count_value
+				count >= found_bm_coven_member_count
 				has_trait = blood_mage
 			}
 		}
@@ -90,8 +90,15 @@ enhance_blood_mage_coven_decision_2 = {
 	is_valid = {
 		exists = house
 		house = {
+			custom_tooltip = {
+				text = found_blood_mage_coven_house_member_count_tt
+				any_adult_house_member = {
+					count >= found_bm_coven_member_count_2
+					has_trait = blood_mage
+				}
+			}
 			any_adult_house_member = {
-				count >= 3
+				count >= found_bm_coven_member_count_2
 				has_trait = blood_mage
 			}
 		}
@@ -145,9 +152,16 @@ enhance_blood_mage_coven_decision_3 = {
 	is_valid = {
 		has_character_modifier = lifeforce_modifier
 		house = {
+			custom_tooltip = {
+				text = found_blood_mage_coven_house_member_count_tt
+				any_adult_house_member = {
+					count >= found_bm_coven_member_count_3
+					has_trait = blood_mage
+				}
+			}
 			any_adult_house_member = {
-				count >= 25
-				has_trait = blood_mage			
+				count >= found_bm_coven_member_count_3
+				has_trait = blood_mage
 			}
 		}
 		or = {
@@ -198,9 +212,16 @@ enhance_blood_mage_coven_decision_4 = {
 	is_valid = {
 		has_character_modifier = lifeforce_modifier
 		house = {
+			custom_tooltip = {
+				text = found_blood_mage_coven_house_member_count_tt
+				any_adult_house_member = {
+					count >= found_bm_coven_member_count_4
+					has_trait = blood_mage
+				}
+			}
 			any_adult_house_member = {
-				count >= 25
-				has_trait = blood_mage			
+				count >= found_bm_coven_member_count_4
+				has_trait = blood_mage
 			}
 		}
 		or = {
@@ -251,9 +272,16 @@ enhance_blood_mage_coven_decision_5 = {
 	is_valid = {
 		has_character_modifier = lifeforce_modifier
 		house = {
+			custom_tooltip = {
+				text = found_blood_mage_coven_house_member_count_tt
+				any_adult_house_member = {
+					count >= found_bm_coven_member_count_5
+					has_trait = blood_mage
+				}
+			}
 			any_adult_house_member = {
-				count >= 50
-				has_trait = blood_mage			
+				count >= found_bm_coven_member_count_5
+				has_trait = blood_mage
 			}
 		}
 		or = { # at least master
@@ -304,9 +332,16 @@ enhance_blood_mage_coven_decision_6 = {
 	is_valid = {
 		has_character_modifier = lifeforce_modifier
 		house = {
+			custom_tooltip = {
+				text = found_blood_mage_coven_house_member_count_tt
+				any_adult_house_member = {
+					count >= found_bm_coven_member_count_6
+					has_trait = blood_mage
+				}
+			}
 			any_adult_house_member = {
-				count >= 50
-				has_trait = blood_mage			
+				count >= found_bm_coven_member_count_6
+				has_trait = blood_mage
 			}
 		}
 		or = {
@@ -357,9 +392,16 @@ enhance_blood_mage_coven_decision_7 = {
 	is_valid = {
 		has_character_modifier = lifeforce_modifier
 		house = {
+			custom_tooltip = {
+				text = found_blood_mage_coven_house_member_count_tt
+				any_adult_house_member = {
+					count >= found_bm_coven_member_count_7
+					has_trait = blood_mage
+				}
+			}
 			any_adult_house_member = {
-				count >= 100
-				has_trait = blood_mage			
+				count >= found_bm_coven_member_count_7
+				has_trait = blood_mage
 			}
 		}
 		or = { 
@@ -411,9 +453,16 @@ enhance_blood_mage_coven_decision_8 = {
 	is_valid = {
 		has_character_modifier = lifeforce_modifier
 		house = {
+			custom_tooltip = {
+				text = found_blood_mage_coven_house_member_count_tt
+				any_adult_house_member = {
+					count >= found_bm_coven_member_count_8
+					has_trait = blood_mage
+				}
+			}
 			any_adult_house_member = {
-				count >= 100
-				has_trait = blood_mage			
+				count >= found_bm_coven_member_count_8
+				has_trait = blood_mage
 			}
 		}
 		or = {
@@ -464,9 +513,16 @@ enhance_blood_mage_coven_decision_9 = {
 	is_valid = {
 		has_character_modifier = lifeforce_modifier
 		house = {
+			custom_tooltip = {
+				text = found_blood_mage_coven_house_member_count_tt
+				any_adult_house_member = {
+					count >= found_bm_coven_member_count_9
+					has_trait = blood_mage
+				}
+			}
 			any_adult_house_member = {
-				count >= 150
-				has_trait = blood_mage			
+				count >= found_bm_coven_member_count_9
+				has_trait = blood_mage
 			}
 		}
 		or = {
@@ -518,9 +574,16 @@ enhance_blood_mage_coven_decision_10 = {
 	is_valid = {
 		has_character_modifier = lifeforce_modifier
 		house = {
+			custom_tooltip = {
+				text = found_blood_mage_coven_house_member_count_tt
+				any_adult_house_member = {
+					count >= found_bm_coven_member_count_10
+					has_trait = blood_mage
+				}
+			}
 			any_adult_house_member = {
-				count >= 200
-				has_trait = blood_mage			
+				count >= found_bm_coven_member_count_10
+				has_trait = blood_mage
 			}
 		}
 		or = { # at least supreme

--- a/common/decisions/bm_major_decisions.txt
+++ b/common/decisions/bm_major_decisions.txt
@@ -43,8 +43,15 @@ enhance_blood_mage_coven_decision_1 = {
 		has_character_modifier = lifeforce_modifier
 
 		house = {
-			any_house_member = {
-				count >= 3
+			custom_tooltip = {
+				text = found_blood_mage_coven_house_member_count_tt
+				any_adult_house_member = {
+					count >= found_blood_mage_coven_member_count_value
+					has_trait = blood_mage
+				}
+			}
+			any_adult_house_member = {
+				count >= found_blood_mage_coven_member_count_value
 				has_trait = blood_mage
 			}
 		}

--- a/common/decisions/bm_major_decisions.txt
+++ b/common/decisions/bm_major_decisions.txt
@@ -35,7 +35,7 @@ enhance_blood_mage_coven_decision_1 = {
 		is_house_head = yes
 		
 		NOT = {
-			exists = var:enhance_bm_1
+			exists = global_var:enhance_bm_1
 		}
 	}
 
@@ -61,7 +61,7 @@ enhance_blood_mage_coven_decision_1 = {
 	effect = { 
 		magic_used = yes
 		enhance_blood_mage_coven_decision_effects = yes
-		set_variable = { name = enhance_bm_1 }
+		set_global_variable = { name = enhance_bm_1 }
 	}
 
 	cost = {
@@ -81,9 +81,9 @@ enhance_blood_mage_coven_decision_2 = {
 		has_trait = blood_mage
 		exists = house
 		is_house_head = yes
-		exists = var:enhance_bm_1
+		exists = global_var:enhance_bm_1
 		NOT = {
-			exists = var:enhance_bm_2
+			exists = global_var:enhance_bm_2
 		}
 	}
 
@@ -119,7 +119,7 @@ enhance_blood_mage_coven_decision_2 = {
 		magic_used = yes
 		add_piety_level = -1
 		enhance_blood_mage_coven_decision_effects = yes
-		set_variable = { 
+		set_global_variable = { 
 			name = enhance_bm_2 
 		}
 	}
@@ -142,10 +142,10 @@ enhance_blood_mage_coven_decision_3 = {
 		has_trait = blood_mage
 		exists = house
 		is_house_head = yes
-		exists = var:enhance_bm_1
-		exists = var:enhance_bm_2
+		exists = global_var:enhance_bm_1
+		exists = global_var:enhance_bm_2
 		NOT = {
-			exists = var:enhance_bm_3
+			exists = global_var:enhance_bm_3
 		}
 	}
 
@@ -179,7 +179,7 @@ enhance_blood_mage_coven_decision_3 = {
 		magic_used = yes
 		add_piety_level = -1
 		enhance_blood_mage_coven_decision_effects = yes
-		set_variable = { 
+		set_global_variable = { 
 			name = enhance_bm_3
 		}
 	}
@@ -201,11 +201,11 @@ enhance_blood_mage_coven_decision_4 = {
 		has_trait = blood_mage
 		exists = house
 		is_house_head = yes
-		exists = var:enhance_bm_1
-		exists = var:enhance_bm_2
-		exists = var:enhance_bm_3
+		exists = global_var:enhance_bm_1
+		exists = global_var:enhance_bm_2
+		exists = global_var:enhance_bm_3
 		NOT = {
-			exists = var:enhance_bm_4
+			exists = global_var:enhance_bm_4
 		}
 	}
 
@@ -238,7 +238,7 @@ enhance_blood_mage_coven_decision_4 = {
 		magic_used = yes
 		add_piety_level = -1
 		enhance_blood_mage_coven_decision_effects = yes
-		set_variable = { 
+		set_global_variable = { 
 			name = enhance_bm_4
 		}
 	}
@@ -260,12 +260,12 @@ enhance_blood_mage_coven_decision_5 = {
 		has_trait = blood_mage
 		exists = house
 		is_house_head = yes
-		exists = var:enhance_bm_1
-		exists = var:enhance_bm_2
-		exists = var:enhance_bm_3
-		exists = var:enhance_bm_4
+		exists = global_var:enhance_bm_1
+		exists = global_var:enhance_bm_2
+		exists = global_var:enhance_bm_3
+		exists = global_var:enhance_bm_4
 		NOT = {
-			exists = var:enhance_bm_5
+			exists = global_var:enhance_bm_5
 		}
 	}
 
@@ -297,7 +297,7 @@ enhance_blood_mage_coven_decision_5 = {
 		magic_used = yes
 		add_piety_level = -2
 		enhance_blood_mage_coven_decision_effects = yes
-		set_variable = { 
+		set_global_variable = { 
 			name = enhance_bm_5
 		}
 	}
@@ -319,13 +319,13 @@ enhance_blood_mage_coven_decision_6 = {
 		has_trait = blood_mage
 		exists = house
 		is_house_head = yes
-		exists = var:enhance_bm_1
-		exists = var:enhance_bm_2
-		exists = var:enhance_bm_3
-		exists = var:enhance_bm_4
-		exists = var:enhance_bm_5
+		exists = global_var:enhance_bm_1
+		exists = global_var:enhance_bm_2
+		exists = global_var:enhance_bm_3
+		exists = global_var:enhance_bm_4
+		exists = global_var:enhance_bm_5
 		NOT = {
-			exists = var:enhance_bm_6
+			exists = global_var:enhance_bm_6
 		}
 	}
 
@@ -356,7 +356,7 @@ enhance_blood_mage_coven_decision_6 = {
 		magic_used = yes
 		add_piety_level = -2
 		enhance_blood_mage_coven_decision_effects = yes
-		set_variable = { 
+		set_global_variable = { 
 			name = enhance_bm_6
 		}
 	}
@@ -378,14 +378,14 @@ enhance_blood_mage_coven_decision_7 = {
 		has_trait = blood_mage
 		exists = house
 		is_house_head = yes
-		exists = var:enhance_bm_1
-		exists = var:enhance_bm_2
-		exists = var:enhance_bm_3
-		exists = var:enhance_bm_4
-		exists = var:enhance_bm_5
-		exists = var:enhance_bm_6
+		exists = global_var:enhance_bm_1
+		exists = global_var:enhance_bm_2
+		exists = global_var:enhance_bm_3
+		exists = global_var:enhance_bm_4
+		exists = global_var:enhance_bm_5
+		exists = global_var:enhance_bm_6
 		NOT = {
-			exists = var:enhance_bm_7
+			exists = global_var:enhance_bm_7
 		}
 	}
 
@@ -415,7 +415,7 @@ enhance_blood_mage_coven_decision_7 = {
 		magic_used = yes
 		add_piety_level = -2
 		enhance_blood_mage_coven_decision_effects = yes
-		set_variable = { 
+		set_global_variable = { 
 			name = enhance_bm_7
 		}
 	}
@@ -437,16 +437,16 @@ enhance_blood_mage_coven_decision_8 = {
 		has_trait = blood_mage
 		exists = house
 		is_house_head = yes
-		exists = var:enhance_bm_1
-		exists = var:enhance_bm_2
-		exists = var:enhance_bm_3
-		exists = var:enhance_bm_4
-		exists = var:enhance_bm_5
-		exists = var:enhance_bm_6
-		exists = var:enhance_bm_7
+		exists = global_var:enhance_bm_1
+		exists = global_var:enhance_bm_2
+		exists = global_var:enhance_bm_3
+		exists = global_var:enhance_bm_4
+		exists = global_var:enhance_bm_5
+		exists = global_var:enhance_bm_6
+		exists = global_var:enhance_bm_7
 
 		NOT = {
-			exists = var:enhance_bm_8
+			exists = global_var:enhance_bm_8
 		}
 	}
 
@@ -475,7 +475,7 @@ enhance_blood_mage_coven_decision_8 = {
 		magic_used = yes
 		add_piety_level = -3
 		enhance_blood_mage_coven_decision_effects = yes
-		set_variable = { 
+		set_global_variable = { 
 			name = enhance_bm_8
 		}
 	}
@@ -497,16 +497,16 @@ enhance_blood_mage_coven_decision_9 = {
 		has_trait = blood_mage
 		exists = house
 		is_house_head = yes
-		exists = var:enhance_bm_1
-		exists = var:enhance_bm_2
-		exists = var:enhance_bm_3
-		exists = var:enhance_bm_4
-		exists = var:enhance_bm_5
-		exists = var:enhance_bm_6
-		exists = var:enhance_bm_7
-		exists = var:enhance_bm_8
+		exists = global_var:enhance_bm_1
+		exists = global_var:enhance_bm_2
+		exists = global_var:enhance_bm_3
+		exists = global_var:enhance_bm_4
+		exists = global_var:enhance_bm_5
+		exists = global_var:enhance_bm_6
+		exists = global_var:enhance_bm_7
+		exists = global_var:enhance_bm_8
 		NOT = {
-			exists = var:enhance_bm_9
+			exists = global_var:enhance_bm_9
 		}
 	}
 
@@ -534,7 +534,7 @@ enhance_blood_mage_coven_decision_9 = {
 		magic_used = yes
 		add_piety_level = -3
 		enhance_blood_mage_coven_decision_effects = yes
-		set_variable = { 
+		set_global_variable = { 
 			name = enhance_bm_9
 		}
 	}
@@ -556,18 +556,18 @@ enhance_blood_mage_coven_decision_10 = {
 		has_trait = blood_mage
 		exists = house
 		is_house_head = yes
-		exists = var:enhance_bm_1
-		exists = var:enhance_bm_2
-		exists = var:enhance_bm_3
-		exists = var:enhance_bm_4
-		exists = var:enhance_bm_5
-		exists = var:enhance_bm_6
-		exists = var:enhance_bm_7
-		exists = var:enhance_bm_8
-		exists = var:enhance_bm_9
+		exists = global_var:enhance_bm_1
+		exists = global_var:enhance_bm_2
+		exists = global_var:enhance_bm_3
+		exists = global_var:enhance_bm_4
+		exists = global_var:enhance_bm_5
+		exists = global_var:enhance_bm_6
+		exists = global_var:enhance_bm_7
+		exists = global_var:enhance_bm_8
+		exists = global_var:enhance_bm_9
 		
 		NOT = {
-			exists = var:enhance_bm_10
+			exists = global_var:enhance_bm_10
 		}
 	}
 
@@ -595,7 +595,7 @@ enhance_blood_mage_coven_decision_10 = {
 		magic_used = yes
 		add_piety_level = -4
 		enhance_blood_mage_coven_decision_effects = yes
-		set_variable = { 
+		set_global_variable = { 
 			name = enhance_bm_10
 		}
 	}

--- a/common/decisions/bm_major_decisions.txt
+++ b/common/decisions/bm_major_decisions.txt
@@ -32,6 +32,7 @@ enhance_blood_mage_coven_decision_1 = {
 	is_shown = {
 		has_trait = blood_mage
 		exists = house
+		is_house_head = yes
 		
 		NOT = {
 			exists = var:enhance_bm_1

--- a/common/script_values/bm_values.txt
+++ b/common/script_values/bm_values.txt
@@ -9,15 +9,15 @@ grant_blood_magic_stress_cost_5 = 50
 found_bm_coven_member_count = {
 	add = 3
 	if = {
-		exists = var:enhance_bm_1
+		limit = { exists = global_var:enhance_bm_1 }
 		add = 2
 	}
 	if = {
-		limit = { exists = var:enhance_bm_2 }
+		limit = { exists = global_var:enhance_bm_2 }
 		add = found_bm_coven_member_count_1
 	}
 	if = {
-		limit = { exists = var:enhance_bm_3 }
+		limit = { exists = global_var:enhance_bm_3 }
 		add = found_bm_coven_member_count_2
 	}
 }

--- a/common/script_values/bm_values.txt
+++ b/common/script_values/bm_values.txt
@@ -6,9 +6,7 @@ grant_blood_magic_stress_cost_4 = 40
 grant_blood_magic_stress_cost_5 = 50
 
 # Coven values
-found_blood_mage_coven_member_count_value = {
-	value = 3
-}
+found_blood_mage_coven_member_count_value = 2
 
 # Lifedraining
 lifedrain_small_stress_cost = 10

--- a/common/script_values/bm_values.txt
+++ b/common/script_values/bm_values.txt
@@ -5,7 +5,7 @@ grant_blood_magic_stress_cost_3 = 30
 grant_blood_magic_stress_cost_4 = 40
 grant_blood_magic_stress_cost_5 = 50
 
-# Coven values
+# Coven values (based on fibbonaci sequence)
 found_bm_coven_member_count = {
 	add = 3
 	if = {
@@ -19,6 +19,30 @@ found_bm_coven_member_count = {
 	if = {
 		limit = { exists = global_var:enhance_bm_3 }
 		add = found_bm_coven_member_count_2
+	}
+	if = {
+		limit = { exists = global_var:enhance_bm_4 }
+		add = found_bm_coven_member_count_3
+	}
+	if = {
+		limit = { exists = global_var:enhance_bm_5 }
+		add = found_bm_coven_member_count_4
+	}
+	if = {
+		limit = { exists = global_var:enhance_bm_6 }
+		add = found_bm_coven_member_count_5
+	}
+	if = {
+		limit = { exists = global_var:enhance_bm_7 }
+		add = found_bm_coven_member_count_6
+	}
+	if = {
+		limit = { exists = global_var:enhance_bm_8 }
+		add = found_bm_coven_member_count_7
+	}
+	if = {
+		limit = { exists = global_var:enhance_bm_9 }
+		add = found_bm_coven_member_count_8
 	}
 }
 

--- a/common/script_values/bm_values.txt
+++ b/common/script_values/bm_values.txt
@@ -6,7 +6,23 @@ grant_blood_magic_stress_cost_4 = 40
 grant_blood_magic_stress_cost_5 = 50
 
 # Coven values
-found_bm_coven_member_count = 3
+found_bm_coven_member_count = {
+	add = 3
+	if = {
+		limit = { exists = var:enhance_bm_1 }
+		add = 2
+	}
+	if = {
+		limit = { exists = var:enhance_bm_2 }
+		add = found_bm_coven_member_count_1
+	}
+	if = {
+		limit = { exists = var:enhance_bm_3 }
+		add = found_bm_coven_member_count_2
+	}
+}
+
+found_bm_coven_member_count_1 = 3
 found_bm_coven_member_count_2 = 5
 found_bm_coven_member_count_3 = 8
 found_bm_coven_member_count_4 = 13

--- a/common/script_values/bm_values.txt
+++ b/common/script_values/bm_values.txt
@@ -9,7 +9,7 @@ grant_blood_magic_stress_cost_5 = 50
 found_bm_coven_member_count = {
 	add = 3
 	if = {
-		limit = { exists = var:enhance_bm_1 }
+		exists = var:enhance_bm_1
 		add = 2
 	}
 	if = {

--- a/common/script_values/bm_values.txt
+++ b/common/script_values/bm_values.txt
@@ -6,7 +6,16 @@ grant_blood_magic_stress_cost_4 = 40
 grant_blood_magic_stress_cost_5 = 50
 
 # Coven values
-found_blood_mage_coven_member_count_value = 2
+found_bm_coven_member_count = 3
+found_bm_coven_member_count_2 = 5
+found_bm_coven_member_count_3 = 8
+found_bm_coven_member_count_4 = 13
+found_bm_coven_member_count_5 = 21
+found_bm_coven_member_count_6 = 34
+found_bm_coven_member_count_7 = 55
+found_bm_coven_member_count_8 = 89
+found_bm_coven_member_count_9 = 144
+found_bm_coven_member_count_10 = 233
 
 # Lifedraining
 lifedrain_small_stress_cost = 10

--- a/common/script_values/bm_values.txt
+++ b/common/script_values/bm_values.txt
@@ -5,6 +5,11 @@ grant_blood_magic_stress_cost_3 = 30
 grant_blood_magic_stress_cost_4 = 40
 grant_blood_magic_stress_cost_5 = 50
 
+# Coven values
+found_blood_mage_coven_member_count_value = {
+	value = 3
+}
+
 # Lifedraining
 lifedrain_small_stress_cost = 10
 lifedrain_piety_cost = 75

--- a/descriptor.mod
+++ b/descriptor.mod
@@ -8,5 +8,5 @@ tags={
 	"Alternative History"
 }
 name="Nicelander's Blood Mage"
-supported_version="1.5.*"
+supported_version="1.6.*"
 remote_file_id="2737082376"

--- a/localization/english/bm_decisions_l_english.yml
+++ b/localization/english/bm_decisions_l_english.yml
@@ -59,3 +59,6 @@
   convert_to_blood_magic_from_witch_desc:0 "Renounce the inferior ways of witches and become a Blood Mage!"
   convert_to_blood_magic_from_witch_confirm:0 "Become a Blood Mage"
   convert_to_blood_magic_from_witch_tooltip:0 "Become a Blood Mage"
+
+  # Custom Tooltip
+   found_blood_mage_coven_house_member_count_tt:0 "[SCOPE.ScriptValue('found_blood_mage_coven_member_count_value')|0] [adult|E] members of your [house|E] are Blood Mages"

--- a/localization/english/bm_decisions_l_english.yml
+++ b/localization/english/bm_decisions_l_english.yml
@@ -7,7 +7,7 @@
   channel_lifeforce_decision_tooltip_desc:0 "Lifeforce is fungible. One can use it in many ways. To become more diplomatic. To have better command over one's armies or one's holdings. To see through the lies and trick others. To understand the more complex topics of this world"
 
  # Enhance Blood Mage Coven - Descriptions
-  enhance_blood_mage_coven_decision_desc:0 "Enhance the power of our dynasty's Blood Mage coven"
+  enhance_blood_mage_coven_decision_desc:0 "As the house head, enhance the power of your dynasty's Blood Mage coven"
 
   # Enhance Blood Mage Coven - Names
   enhance_blood_mage_coven_decision_1:0 "Found Blood Mage Coven"

--- a/localization/english/bm_decisions_l_english.yml
+++ b/localization/english/bm_decisions_l_english.yml
@@ -10,7 +10,7 @@
   enhance_blood_mage_coven_decision_desc:0 "Enhance the power of our dynasty's Blood Mage coven"
 
   # Enhance Blood Mage Coven - Names
-  enhance_blood_mage_coven_decision_1:0 "Enhance Blood Mage Coven"
+  enhance_blood_mage_coven_decision_1:0 "Found Blood Mage Coven"
   enhance_blood_mage_coven_decision_2:0 "Enhance Blood Mage Coven"
   enhance_blood_mage_coven_decision_3:0 "Enhance Blood Mage Coven"
   enhance_blood_mage_coven_decision_4:0 "Enhance Blood Mage Coven"
@@ -34,7 +34,7 @@
   enhance_blood_mage_coven_decision_10_tooltip:0 "Enhance the power of our Blood Mage Coven"
 
   # Enhance Blood Mage Coven - Confirm Button
-  enhance_blood_mage_coven_decision_1_confirm:0 "Enhance the Coven"
+  enhance_blood_mage_coven_decision_1_confirm:0 "Found the Coven"
   enhance_blood_mage_coven_decision_2_confirm:0 "Enhance the Coven"
   enhance_blood_mage_coven_decision_3_confirm:0 "Enhance the Coven"
   enhance_blood_mage_coven_decision_4_confirm:0 "Enhance the Coven"

--- a/localization/english/bm_decisions_l_english.yml
+++ b/localization/english/bm_decisions_l_english.yml
@@ -61,4 +61,4 @@
   convert_to_blood_magic_from_witch_tooltip:0 "Become a Blood Mage"
 
   # Custom Tooltip
-   found_blood_mage_coven_house_member_count_tt:0 "[SCOPE.ScriptValue('found_blood_mage_coven_member_count_value')|0] [adult|E] members of your [house|E] are Blood Mages"
+  found_bm_coven_member_count_tt:0 "[SCOPE.ScriptValue('found_bm_coven_member_count')|0] [adult|E] members of your [house|E] are Blood Mages"


### PR DESCRIPTION
* Update to 1.6
* Change minimum blood mages in the dynasty requirement to level up Blood Mage coven. Now based on Fibonacci sequence, starting with 3 to found the coven, 5 for 2nd rank, 8 for 3rd, etc
* Fixed localisation issues for blood mage coven