### PR TITLE
16.05: Rule to disable cult (religion) // Failed trait drain leaves target weakened // Fix gender description // Zealous AI wont convert to cult

### DIFF
--- a/common/character_interactions/bm_grant_blood_magic.txt
+++ b/common/character_interactions/bm_grant_blood_magic.txt
@@ -42,7 +42,6 @@
         ai_recipients = children
         ai_recipients = courtiers
         ai_recipients = councillors
-        ai_recipients = liege
     }
     ai_will_do = {
         base = 0

--- a/common/decisions/bm_become_blood_cultist_decision.txt
+++ b/common/decisions/bm_become_blood_cultist_decision.txt
@@ -24,6 +24,22 @@
     }
 
     # Yearly chance AI take up the religion if they are a blood mage
-    ai_will_do = { base = 10 }
     ai_check_interval = 12
+    ai_will_do = { 
+        base = 10 
+        modifier = {
+            add = -100
+            OR = {
+                has_trait = zealous
+                has_trait = content
+            }
+        }
+        modifier = {
+            add = 10
+            OR = {
+                has_trait = ambitious
+                has_trait = wise_man
+            }
+        }
+    }
 }

--- a/common/decisions/bm_become_blood_cultist_decision.txt
+++ b/common/decisions/bm_become_blood_cultist_decision.txt
@@ -10,6 +10,7 @@
         NOT = { faith = { religion = { is_in_family = rf_quintessence } } }
         # Disable for overhaul mods
         NOT = { is_playing_overhaul_mod = yes }
+        has_game_rule = game_rule_quintessence_religion_enabled
     }
     is_valid = { 
         has_trait = lifestyle_blood_mage

--- a/common/decisions/bm_become_blood_cultist_decision.txt
+++ b/common/decisions/bm_become_blood_cultist_decision.txt
@@ -10,7 +10,7 @@
         NOT = { faith = { religion = { is_in_family = rf_quintessence } } }
         # Disable for overhaul mods
         NOT = { is_playing_overhaul_mod = yes }
-        has_game_rule = game_rule_quintessence_religion_enabled
+        has_game_rule = quintessence_religion_enabled
     }
     is_valid = { 
         has_trait = lifestyle_blood_mage

--- a/common/game_rules/bm_game_rules.txt
+++ b/common/game_rules/bm_game_rules.txt
@@ -2,7 +2,7 @@
 	categories = {
 		game_modes tweaks faith ai
 	}
-	default = quintessence_religion_enabled
+	default = game_rule_quintessence_religion_enabled
     game_rule_quintessence_religion_enabled = {
     }
     game_rule_quintessence_religion_disabled = {

--- a/common/game_rules/bm_game_rules.txt
+++ b/common/game_rules/bm_game_rules.txt
@@ -1,0 +1,10 @@
+﻿game_rule_quintessence_religion = {
+	categories = {
+		game_modes tweaks faith ai
+	}
+	default = quintessence_religion_enabled
+    game_rule_quintessence_religion_enabled = {
+    }
+    game_rule_quintessence_religion_disabled = {
+    }
+}

--- a/common/game_rules/bm_game_rules.txt
+++ b/common/game_rules/bm_game_rules.txt
@@ -1,6 +1,6 @@
 ﻿game_rule_quintessence_religion = {
 	categories = {
-		game_modes tweaks faith ai
+		game_modes tweaks faith
 	}
 	default = game_rule_quintessence_religion_enabled
     game_rule_quintessence_religion_enabled = {

--- a/common/game_rules/bm_game_rules.txt
+++ b/common/game_rules/bm_game_rules.txt
@@ -1,10 +1,10 @@
-﻿game_rule_quintessence_religion = {
+﻿quintessence_religion = {
 	categories = {
 		game_modes tweaks faith
 	}
-	default = game_rule_quintessence_religion_enabled
-    game_rule_quintessence_religion_enabled = {
+	default = quintessence_religion_enabled
+    quintessence_religion_enabled = {
     }
-    game_rule_quintessence_religion_disabled = {
+    quintessence_religion_disabled = {
     }
 }

--- a/common/modifiers/bm_lifeforce.txt
+++ b/common/modifiers/bm_lifeforce.txt
@@ -58,6 +58,16 @@ lifedrained_modifier = {
     prowess = -5
 }
 
+trait_drained_attempted_modifier = {
+    icon = health_negative
+    stacking = yes
+
+    health = -1
+    life_expectancy = -10
+    epidemic_resistance = -10
+    negate_health_penalty_add = -1
+}
+
 lifeforce_modifier_crimson_warrior = {
     icon = blood_positive
     health = -0.2

--- a/common/modifiers/bm_lifeforce.txt
+++ b/common/modifiers/bm_lifeforce.txt
@@ -62,10 +62,10 @@ trait_drained_attempted_modifier = {
     icon = health_negative
     stacking = yes
 
-    health = -1
-    life_expectancy = -10
-    epidemic_resistance = -10
-    negate_health_penalty_add = -1
+    health = -0.5
+    life_expectancy = -5
+    epidemic_resistance = -5
+    negate_health_penalty_add = -0.5
 }
 
 lifeforce_modifier_crimson_warrior = {

--- a/common/scripted_effects/bm_blood_magic_temporary_effects.txt
+++ b/common/scripted_effects/bm_blood_magic_temporary_effects.txt
@@ -17,3 +17,9 @@ temporary_trait_drain_attempted = {
         days = 185
     }
 }
+temporary_negative_recently_trait_drained = {
+    add_character_modifier = {
+        modifier = trait_drained_attempted_modifier
+        days = 365
+    }
+}

--- a/description.txt
+++ b/description.txt
@@ -61,7 +61,7 @@ Blood Mages can follow their own unique faith, The Cult of Quintessence: https:/
     [*] [b]Christian Syncretism[/b] allows Blood Cultists to live their pagan ways without being hated by their Christian neighbours.
 [/list]
 
-Religion disabled for LOTR/EK2/AGOT, but works in PoD.
+The Cult is disabled for LOTR/EK2/AGOT, but works in PoD.
 
 [h1]Getting Started[/h1]
 There are various ways to gain the Blood Mage trait
@@ -69,7 +69,7 @@ There are various ways to gain the Blood Mage trait
     [*] Select the Blood Mage trait at character creation
     [*] Ask a Blood Mage friend/lover/soulmate to grant you the power
     [*] Convert from being a witch to a Blood Mage (not AI, so other witches can exist)
-    [*] Join the Cult of Blood and complete the transformation ritual
+    [*] Join the Cult and complete the transformation ritual
     [*] Consume other Blood Mages you've imprisoned
     [*] Small chance the AI is randomly born with it
 [/list]

--- a/events/bm_trait_drain_events.txt
+++ b/events/bm_trait_drain_events.txt
@@ -40,6 +40,7 @@ bm_trait_drain.001 = {
                 }
             }
             50 = {
+                scope:recipient = { temporary_negative_recently_trait_drained = yes }
                 modifier = { add = trait_drain_modifier_per_trait }
                 send_interface_toast = {
                     title = bm_trait_drain.001.fail
@@ -86,6 +87,7 @@ bm_trait_drain.001 = {
                 }
             }
             50 = {
+                scope:recipient = { temporary_negative_recently_trait_drained = yes }
                 modifier = { add = trait_drain_modifier_per_trait }
                 send_interface_toast = {
                     title = bm_trait_drain.001.fail
@@ -132,6 +134,7 @@ bm_trait_drain.001 = {
                 }
             }
             50 = {
+                scope:recipient = { temporary_negative_recently_trait_drained = yes }
                 modifier = { add = trait_drain_modifier_per_trait }
                 send_interface_toast = {
                     title = bm_trait_drain.001.fail
@@ -180,6 +183,7 @@ bm_trait_drain.001 = {
                 }
             }
             50 = {
+                scope:recipient = { temporary_negative_recently_trait_drained = yes }
                 modifier = { add = trait_drain_modifier_per_trait }
                 send_interface_toast = {
                     title = bm_trait_drain.001.fail
@@ -228,6 +232,7 @@ bm_trait_drain.001 = {
                 }
             }
             50 = {
+                scope:recipient = { temporary_negative_recently_trait_drained = yes }
                 modifier = { add = trait_drain_modifier_per_trait }
                 send_interface_toast = {
                     title = bm_trait_drain.001.fail
@@ -277,6 +282,7 @@ bm_trait_drain.001 = {
                 }
             }
             50 = {
+                scope:recipient = { temporary_negative_recently_trait_drained = yes }
                 modifier = { add = trait_drain_modifier_per_trait }
                 send_interface_toast = {
                     title = bm_trait_drain.001.fail

--- a/localization/english/bm_game_rules.yml
+++ b/localization/english/bm_game_rules.yml
@@ -1,6 +1,0 @@
-﻿l_english:
-  rule_quintessence_religion: "Blood Mage: Quintessence Religion"
-  setting_quintessence_religion_enabled: "Enabled"
-  setting_quintessence_religion_enabled_desc: "Religion decision enabled."
-  setting_quintessence_religion_disabled: "Disabled"
-  setting_quintessence_religion_enabled_desc: "Religion decision disabled."

--- a/localization/english/bm_game_rules.yml
+++ b/localization/english/bm_game_rules.yml
@@ -1,6 +1,6 @@
 ﻿l_english:
-  rule_game_rule_quintessence_religion: "Blood Mage: Quintessence Religion"
-  setting_game_rule_quintessence_religion_enabled: "Enabled"
-  setting_game_rule_quintessence_religion_enabled_desc: "Religion decision enabled."
-  setting_game_rule_quintessence_religion_disabled: "Disabled"
-  setting_game_rule_quintessence_religion_enabled_desc: "Religion decision disabled."
+  rule_quintessence_religion: "Blood Mage: Quintessence Religion"
+  setting_quintessence_religion_enabled: "Enabled"
+  setting_quintessence_religion_enabled_desc: "Religion decision enabled."
+  setting_quintessence_religion_disabled: "Disabled"
+  setting_quintessence_religion_enabled_desc: "Religion decision disabled."

--- a/localization/english/bm_game_rules.yml
+++ b/localization/english/bm_game_rules.yml
@@ -1,0 +1,5 @@
+﻿l_english:
+  game_rule_quintessence_religion: "Quintessence Religion"
+  game_rule_quintessence_religion_enabled: "Enabled"
+  game_rule_quintessence_religion_disabled: "Disabled"
+

--- a/localization/english/bm_game_rules.yml
+++ b/localization/english/bm_game_rules.yml
@@ -1,6 +1,6 @@
 ﻿l_english:
   rule_game_rule_quintessence_religion: "Blood Mage: Quintessence Religion"
   setting_game_rule_quintessence_religion_enabled: "Enabled"
-  setting_game_rule_quintessence_religion_enabled_desc: "Quintessence Religion decision enabled."
+  setting_game_rule_quintessence_religion_enabled_desc: "Religion decision enabled."
   setting_game_rule_quintessence_religion_disabled: "Disabled"
-  setting_game_rule_quintessence_religion_enabled_desc: "Quintessence Religion decision disabled."
+  setting_game_rule_quintessence_religion_enabled_desc: "Religion decision disabled."

--- a/localization/english/bm_game_rules.yml
+++ b/localization/english/bm_game_rules.yml
@@ -1,5 +1,6 @@
 ﻿l_english:
-  game_rule_quintessence_religion: "Quintessence Religion"
-  game_rule_quintessence_religion_enabled: "Enabled"
-  game_rule_quintessence_religion_disabled: "Disabled"
-
+  rule_game_rule_quintessence_religion: "Blood Mage: Quintessence Religion"
+  setting_game_rule_quintessence_religion_enabled: "Enabled"
+  setting_game_rule_quintessence_religion_enabled_desc: "Quintessence Religion decision enabled."
+  setting_game_rule_quintessence_religion_disabled: "Disabled"
+  setting_game_rule_quintessence_religion_enabled_desc: "Quintessence Religion decision disabled."

--- a/localization/english/bm_game_rules_l_english.yml
+++ b/localization/english/bm_game_rules_l_english.yml
@@ -1,0 +1,6 @@
+﻿l_english:
+  rule_quintessence_religion:0 "Blood Mage: Quintessence Religion"
+  setting_quintessence_religion_enabled:0 "Enabled"
+  setting_quintessence_religion_enabled_desc:0 "Religion decision enabled."
+  setting_quintessence_religion_disabled:0 "Disabled"
+  setting_quintessence_religion_enabled_desc:0 "Religion decision disabled."

--- a/localization/english/bm_game_rules_l_english.yml
+++ b/localization/english/bm_game_rules_l_english.yml
@@ -1,6 +1,6 @@
 ﻿l_english:
-  rule_quintessence_religion:0 "Blood Mage: Quintessence Religion"
-  setting_quintessence_religion_enabled:0 "Enabled"
-  setting_quintessence_religion_enabled_desc:0 "Religion decision enabled."
-  setting_quintessence_religion_disabled:0 "Disabled"
-  setting_quintessence_religion_enabled_desc:0 "Religion decision disabled."
+  rule_quintessence_religion: "Blood Mage: Quintessence Religion"
+  setting_quintessence_religion_enabled: "Enabled"
+  setting_quintessence_religion_enabled_desc: "Religion decision enabled."
+  setting_quintessence_religion_disabled: "Disabled"
+  setting_quintessence_religion_enabled_desc: "Religion decision disabled."

--- a/localization/english/bm_game_rules_l_english.yml
+++ b/localization/english/bm_game_rules_l_english.yml
@@ -1,6 +1,6 @@
 ﻿l_english:
-  rule_quintessence_religion: "Blood Mage: Quintessence Religion"
+  rule_quintessence_religion: "Blood Mage: Quintessence Cult"
   setting_quintessence_religion_enabled: "Enabled"
-  setting_quintessence_religion_enabled_desc: "Religion decision enabled."
+  setting_quintessence_religion_enabled_desc: "Joining the cult decision ENABLED."
   setting_quintessence_religion_disabled: "Disabled"
-  setting_quintessence_religion_enabled_desc: "Religion decision disabled."
+  setting_quintessence_religion_disabled_desc: "Joining the cult decision DISABLED."

--- a/localization/english/bm_modifiers_l_english.yml
+++ b/localization/english/bm_modifiers_l_english.yml
@@ -128,7 +128,7 @@ crimson_expertise_modifier_desc: "Blood magic accelerates your learning capabili
 trait_drain_attempted: "Trait Drain Recently Attempted"
 trait_drain_attempted_desc: "I must wait before trying to trait drain again"
 
-trait_drained_attempted_modifier: "A Blood Mage tried to drain my trait"
+trait_drained_attempted_modifier: "A Blood Mage tried to drain me"
 trait_drained_attempted_modifier_desc: "My body is weak from the recently attempted drain"
 
 # Major, temporary buffs (fallback so you can always get something)

--- a/localization/english/bm_modifiers_l_english.yml
+++ b/localization/english/bm_modifiers_l_english.yml
@@ -128,6 +128,9 @@ crimson_expertise_modifier_desc: "Blood magic accelerates your learning capabili
 trait_drain_attempted: "Trait Drain Recently Attempted"
 trait_drain_attempted_desc: "I must wait before trying to trait drain again"
 
+trait_drained_attempted_modifier: "A Blood Mage tried to drain my trait"
+trait_drained_attempted_modifier_desc: "My body is weak from the recently attempted drain"
+
 # Major, temporary buffs (fallback so you can always get something)
 temporary_buff_bloodline: "Bloodline Crimson Empowered"
 temporary_buff_bloodline_desc: "Bloodline Crimson Empowered"

--- a/localization/english/event_localization/bm_mass_lifedrain_events_l_english.yml
+++ b/localization/english/event_localization/bm_mass_lifedrain_events_l_english.yml
@@ -1,6 +1,6 @@
 ﻿l_english:
   # Death reason
-  death_lifedrain_reason: "Had his life drained out of him by a Blood Mage"
+  death_lifedrain_reason: "Had their life drained out of them by a Blood Mage"
 
   # Mass lifedrain
   mass_lifedrain_prisoners_decision: "Harvest Lifeforce from all Prisoners"


### PR DESCRIPTION
- Fix gender in description of being killed by blood mage
- Failed trait draining leaves the victim weakened, making them more likely to die in jail
- Zealous AI won't convert to cult. Ambitious more likely to do so.
- Game Rule: Disbale cult / religion